### PR TITLE
Adding dscanner

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -1,0 +1,4 @@
+[analysis.config.StaticAnalysisConfig]
+
+; Checks for undocumented public declarations
+undocumented_declaration_check="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,15 @@ addons:
     sources:
       - debian-sid
 
+install:
+  # Downloads and compiles dscanner - tool for analyzing D source code
+  - git clone --depth=1 --recursive https://github.com/Hackerpilot/Dscanner.git ~/Dscanner
+  - if [ ${DC} = "dmd" ]; then make -C ~/Dscanner; fi
+
 script:
+  # Dscanner check
+  - if [ ${DC} = "dmd" ]; then ~/Dscanner/bin/dscanner -s --config=.dscanner.ini; fi
+  - if [ ${DC} = "dmd" ]; then ~/Dscanner/bin/dscanner -S --config=.dscanner.ini; fi
+
+  # Main check
   - dub build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ install:
   - git clone --depth=1 --recursive https://github.com/Hackerpilot/Dscanner.git ~/Dscanner
   - if [ ${DC} = "dmd" ]; then make -C ~/Dscanner; fi
 
-script:
+before_script:
   # Dscanner check
   - if [ ${DC} = "dmd" ]; then ~/Dscanner/bin/dscanner -s --config=.dscanner.ini; fi
   - if [ ${DC} = "dmd" ]; then ~/Dscanner/bin/dscanner -S --config=.dscanner.ini; fi
 
+script:
   # Main check
   - dub build


### PR DESCRIPTION
Перед сборкой парсит код на наличие всяких двусмысленностей и косяков.

Если находит не останавливает сборку (пока так оставим), в будущем можно будет сделать чтобы при неудачной проверке вываливалась ошибка.

Но полезно просматривать вывод этой утилиты перед мёрджем.